### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm --filter apps/web build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./apps/web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -67,3 +67,9 @@ To start the development server, install dependencies and run the `dev` script f
 pnpm install
 pnpm --filter apps/web dev
 ```
+
+## GitHub Pages
+
+This repository includes a workflow that builds the `web` app and deploys it to
+GitHub Pages whenever changes are pushed to the `main` branch. The static files
+are generated into `apps/web/dist` and served from the `gh-pages` branch.

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/codex_test/',
 })


### PR DESCRIPTION
## Summary
- deploy `apps/web` using GitHub Pages
- configure Vite to use the proper base path
- document the GitHub Pages workflow

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org)*
- `pnpm --filter apps/web build` *(fails: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_684853db5228832cacfcf2c22ee70bcd