### PR TITLE
Fix missing React types for components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3,5 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "peerDependencies": {
+    "react": "^19.1.0"
+  },
+  "devDependencies": {
+    "react": "^19.1.0",
+    "@types/react": "^19.1.2"
+  }
 }


### PR DESCRIPTION
## Summary
- add React peer dep and types to components package

## Testing
- `pnpm --filter apps/web build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684859367298832c905cbd2eb7894875