### PR TITLE
Fix tsconfig path for components

### DIFF
--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@codex/tsconfig/app",
+  "extends": "../tsconfig/tsconfig.app.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo"
   },


### PR DESCRIPTION
## Summary
- reference local shared tsconfig instead of npm package

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68485b816d7c832c88407246d173d5a4